### PR TITLE
Cp 44 implement single quiz view quiz info section

### DIFF
--- a/src/Api/quizzes.ts
+++ b/src/Api/quizzes.ts
@@ -67,3 +67,23 @@ export const useCreateQuiz = () => {
     },
   });
 };
+
+interface GetQuizFnProps {
+  quizId?: string;
+}
+
+export const GetQuizFn = async (quizId?: string) => {
+  if (!quizId) return;
+  const res = await axios.get(
+    process.env.REACT_APP_SERVER_URL + `/quiz?quiz_id=${quizId}`,
+    reqOptions
+  );
+  return res.data.data;
+};
+
+export const useGetQuiz = (props: GetQuizFnProps) => {
+  return useQuery({
+    queryKey: ["get_quiz", props.quizId],
+    queryFn: () => GetQuizFn(props.quizId),
+  });
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,7 @@ const QuizzesRoutes = () => (
   <Routes>
     <Route index element={<QuizzesView />} />
     <Route path="/new" element={<CreateQuizView />} />
-    <Route path="/:quiz_id" element={<QuizDetailsView />} />
+    <Route path="/:quizId" element={<QuizDetailsView />} />
   </Routes>
 );
 

--- a/src/Components/QuizDetails/InfoSideMenu.tsx
+++ b/src/Components/QuizDetails/InfoSideMenu.tsx
@@ -1,0 +1,41 @@
+import { Grid } from "@mui/material";
+import { QuizType } from "../../types";
+import { QuizInfoSection } from "./QuizInfoSection";
+import { SourcesList } from "./SourcesList";
+
+export interface ResponseSourceType {
+  created_at: string;
+  file_hash: string;
+  file_name: string;
+  source_id: number;
+}
+
+export interface QuizInfoType {
+  quiz: QuizType;
+  sources: ResponseSourceType[];
+}
+
+export const InfoSideMenu = ({ quizInfo }: { quizInfo: QuizInfoType }) => {
+  const { quiz, sources } = quizInfo;
+
+  return (
+    <Grid
+      item
+      xs={4.5}
+      sm={3}
+      md={2}
+      direction="column"
+      sx={{
+        borderRight: "1px solid silver",
+        height: "100%",
+        display: "flex",
+        gap: "0.5rem",
+        minWidth: "12.5rem",
+        overflow: "hidden",
+      }}
+    >
+      <QuizInfoSection quiz={quiz} />
+      <SourcesList sources={sources} />
+    </Grid>
+  );
+};

--- a/src/Components/QuizDetails/QuizInfoSection.tsx
+++ b/src/Components/QuizDetails/QuizInfoSection.tsx
@@ -1,0 +1,41 @@
+import { Grid } from "@mui/material";
+import { QuizType } from "../../types";
+
+export const QuizInfoSection = ({ quiz }: { quiz: QuizType }) => {
+  const titleKeyPairs = [
+    {
+      title: "Quiz Title",
+      val: quiz.quiz_title,
+    },
+    {
+      title: "Quiz Description",
+      val: quiz.quiz_description,
+    },
+    { title: "Keywords", val: quiz.keywords },
+    { title: "Metaprompt", val: quiz.meta_prompt },
+  ];
+
+  return (
+    <>
+      {titleKeyPairs.map(({ title, val }, index) => {
+        return (
+          <Grid
+            item
+            key={index}
+            direction="column"
+            sx={{
+              display: "flex",
+              gap: "0.25rem",
+              fontSize: "0.9rem",
+              padding: "0.25rem 0.25rem 0.25rem 0",
+              lineHeight: "1.5",
+            }}
+          >
+            <strong>{title}</strong>
+            <span>{val || "Not available"}</span>
+          </Grid>
+        );
+      })}
+    </>
+  );
+};

--- a/src/Components/QuizDetails/SourcesList.tsx
+++ b/src/Components/QuizDetails/SourcesList.tsx
@@ -1,0 +1,27 @@
+import { Grid } from "@mui/material";
+import { type ResponseSourceType } from "./InfoSideMenu";
+
+export const SourcesList = ({ sources }: { sources: ResponseSourceType[] }) => {
+  return (
+    <Grid
+      direction="column"
+      sx={{
+        display: "flex",
+        gap: "0.75rem",
+        fontSize: "0.9rem",
+        padding: "0.25rem 0.25rem 0.25rem 0",
+        overflow: "auto",
+      }}
+    >
+      <strong>Sources</strong>
+
+      {sources.map((source, index) => {
+        return (
+          <span key={index}>
+            {index + 1}) {source.file_name}
+          </span>
+        );
+      })}
+    </Grid>
+  );
+};

--- a/src/Layouts/layouts.css
+++ b/src/Layouts/layouts.css
@@ -3,6 +3,7 @@
   grid-template-rows: 4rem auto;
   height: 100vh;
   overflow: hidden;
+  background-color: #f8f8f8;
 }
 
 .view-content-container {

--- a/src/Views/QuizDetails/index.tsx
+++ b/src/Views/QuizDetails/index.tsx
@@ -18,7 +18,7 @@ function QuizDetailsView() {
     <DefaultLayout>
       <Grid container sx={{ height: "100%" }}>
         <QuizInfoSection quizInfo={quizInfo} />
-        <Grid item xs={8}>
+        <Grid item xs="auto">
           Right Section
         </Grid>
       </Grid>
@@ -60,7 +60,8 @@ const QuizInfoSection = ({ quizInfo }: { quizInfo: QuizInfoType }) => {
     <Grid
       item
       xs={4.5}
-      md={3}
+      sm={3}
+      md={2}
       direction="column"
       sx={{
         borderRight: "1px solid silver",

--- a/src/Views/QuizDetails/index.tsx
+++ b/src/Views/QuizDetails/index.tsx
@@ -1,9 +1,8 @@
 import { useParams } from "react-router-dom";
 import { useGetQuiz } from "../../Api/quizzes";
 import DefaultLayout from "../../Layouts/DefaultLayout";
-import { Grid, Container, Typography } from "@mui/material";
-import { QuizType } from "../../types";
-import Flex from "../../Ui/Flex";
+import { Grid } from "@mui/material";
+import { InfoSideMenu } from "../../Components/QuizDetails/InfoSideMenu";
 
 function QuizDetailsView() {
   const { quizId } = useParams();
@@ -17,7 +16,7 @@ function QuizDetailsView() {
   return (
     <DefaultLayout>
       <Grid container sx={{ height: "100%" }}>
-        <QuizInfoSection quizInfo={quizInfo} />
+        <InfoSideMenu quizInfo={quizInfo} />
         <Grid item xs="auto">
           Right Section
         </Grid>
@@ -27,91 +26,3 @@ function QuizDetailsView() {
 }
 
 export default QuizDetailsView;
-
-interface ResponseSourceType {
-  created_at: string;
-  file_hash: string;
-  file_name: string;
-  source_id: number;
-}
-
-interface QuizInfoType {
-  quiz: QuizType;
-  sources: ResponseSourceType[];
-}
-
-const QuizInfoSection = ({ quizInfo }: { quizInfo: QuizInfoType }) => {
-  const { quiz, sources } = quizInfo;
-
-  const titleKeyPairs = [
-    {
-      title: "Quiz Title",
-      val: quiz.quiz_title,
-    },
-    {
-      title: "Quiz Description",
-      val: quiz.quiz_description,
-    },
-    { title: "Keywords", val: quiz.keywords },
-    { title: "Metaprompt", val: quiz.meta_prompt },
-  ];
-
-  return (
-    <Grid
-      item
-      xs={4.5}
-      sm={3}
-      md={2}
-      direction="column"
-      sx={{
-        borderRight: "1px solid silver",
-        height: "100%",
-        display: "flex",
-        gap: "0.5rem",
-        minWidth: "12.5rem",
-        overflow: "hidden",
-      }}
-    >
-      {titleKeyPairs.map(({ title, val }, index) => {
-        return (
-          <Grid
-            item
-            key={index}
-            direction="column"
-            sx={{
-              display: "flex",
-              gap: "0.25rem",
-              fontSize: "0.9rem",
-              padding: "0.25rem 0.25rem 0.25rem 0",
-              lineHeight: "1.5",
-            }}
-          >
-            <strong>{title}</strong>
-            <span>{val || "Not available"}</span>
-          </Grid>
-        );
-      })}
-
-      <Grid
-        direction="column"
-        sx={{
-          display: "flex",
-          gap: "0.75rem",
-          fontSize: "0.9rem",
-          padding: "0.25rem 0.25rem 0.25rem 0",
-          overflow: "auto",
-        }}
-      >
-        <strong>Sources</strong>
-
-        {sources.map((source, index) => {
-          return (
-            <span key={index}>
-              {index + 1}) {source.file_name}
-            </span>
-          );
-        })}
-      </Grid>
-    </Grid>
-  );
-};

--- a/src/Views/QuizDetails/index.tsx
+++ b/src/Views/QuizDetails/index.tsx
@@ -1,7 +1,116 @@
+import { useParams } from "react-router-dom";
+import { useGetQuiz } from "../../Api/quizzes";
 import DefaultLayout from "../../Layouts/DefaultLayout";
+import { Grid, Container, Typography } from "@mui/material";
+import { QuizType } from "../../types";
+import Flex from "../../Ui/Flex";
 
 function QuizDetailsView() {
-  return <DefaultLayout>QuizDetailsView</DefaultLayout>;
+  const { quizId } = useParams();
+
+  const { data: quizInfo, isLoading, isError, error } = useGetQuiz({ quizId });
+
+  if (isLoading) {
+    return <p>Loading</p>;
+  }
+
+  return (
+    <DefaultLayout>
+      <Grid container sx={{ height: "100%" }}>
+        <QuizInfoSection quizInfo={quizInfo} />
+        <Grid item xs={8}>
+          Right Section
+        </Grid>
+      </Grid>
+    </DefaultLayout>
+  );
 }
 
 export default QuizDetailsView;
+
+interface ResponseSourceType {
+  created_at: string;
+  file_hash: string;
+  file_name: string;
+  source_id: number;
+}
+
+interface QuizInfoType {
+  quiz: QuizType;
+  sources: ResponseSourceType[];
+}
+
+const QuizInfoSection = ({ quizInfo }: { quizInfo: QuizInfoType }) => {
+  const { quiz, sources } = quizInfo;
+
+  const titleKeyPairs = [
+    {
+      title: "Quiz Title",
+      val: quiz.quiz_title,
+    },
+    {
+      title: "Quiz Description",
+      val: quiz.quiz_description,
+    },
+    { title: "Keywords", val: quiz.keywords },
+    { title: "Metaprompt", val: quiz.meta_prompt },
+  ];
+
+  return (
+    <Grid
+      item
+      xs={4.5}
+      md={3}
+      direction="column"
+      sx={{
+        borderRight: "1px solid silver",
+        height: "100%",
+        display: "flex",
+        gap: "0.5rem",
+        minWidth: "12.5rem",
+        overflow: "hidden",
+      }}
+    >
+      {titleKeyPairs.map(({ title, val }, index) => {
+        return (
+          <Grid
+            item
+            key={index}
+            direction="column"
+            sx={{
+              display: "flex",
+              gap: "0.25rem",
+              fontSize: "0.9rem",
+              padding: "0.25rem 0.25rem 0.25rem 0",
+              lineHeight: "1.5",
+            }}
+          >
+            <strong>{title}</strong>
+            <span>{val || "Not available"}</span>
+          </Grid>
+        );
+      })}
+
+      <Grid
+        direction="column"
+        sx={{
+          display: "flex",
+          gap: "0.75rem",
+          fontSize: "0.9rem",
+          padding: "0.25rem 0.25rem 0.25rem 0",
+          overflow: "auto",
+        }}
+      >
+        <strong>Sources</strong>
+
+        {sources.map((source, index) => {
+          return (
+            <span key={index}>
+              {index + 1}) {source.file_name}
+            </span>
+          );
+        })}
+      </Grid>
+    </Grid>
+  );
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,8 @@ export interface QuizType {
   quiz_id: string;
   quiz_title: string;
   quiz_description: string;
+  keywords: string;
+  meta_prompt: string;
   created_at: Date;
   is_active: boolean;
 }


### PR DESCRIPTION
### Description

This PR adds the first iteration of quiz details view. The quiz information is fetched on page load and displayed on the left side panel. Right section with questions and a link to question creation will be implemented.

### Checklist

- [ ] I tested the implementation on Preview link and everything works as expected
- [ ] I fixed all the issues found by the linter
- [ ] I extended README / documentation, if necessary

### Screenshot (optional)

![image](https://github.com/berk245/quiz-generator-client/assets/32645610/5fe31760-d7b1-49ab-9191-ff990cc4911c)

