### PR TITLE
Cp 66 improve meta prompt

### DIFF
--- a/src/Components/CreateQuiz/FormContainer/FormSteps/KeywordsForm.tsx
+++ b/src/Components/CreateQuiz/FormContainer/FormSteps/KeywordsForm.tsx
@@ -39,8 +39,8 @@ export default function KeywordsForm() {
     <Grid container>
       <FormStepTitle>Keywords and Concepts</FormStepTitle>
       <Typography variant="subtitle2">
-        Provide keywords and key concepts that you want the quiz generator to
-        pay special attention on.
+        (Optional) Provide keywords and key concepts that you want the quiz
+        generator to pay special attention on.
       </Typography>
       <Grid container spacing={5}>
         <Grid item xs={12} sm={12}>

--- a/src/Components/CreateQuiz/FormContainer/FormSteps/QuizInstructionsForm.tsx
+++ b/src/Components/CreateQuiz/FormContainer/FormSteps/QuizInstructionsForm.tsx
@@ -6,7 +6,7 @@ import { useAtom } from "jotai";
 import { newQuizDataAtom } from "../../../../Views/CreateQuiz/atoms";
 import FormStepTitle from "./FormStepTitle";
 
-export default function MetaPromptForm() {
+export default function QuizInstructionsForm() {
   const [newQuizData, setNewQuizData] = useAtom(newQuizDataAtom);
 
   const handleChange = (e: any) => {
@@ -18,7 +18,7 @@ export default function MetaPromptForm() {
 
   return (
     <Grid container>
-      <FormStepTitle>Meta-prompts</FormStepTitle>
+      <FormStepTitle>Quiz Level Instructions</FormStepTitle>
 
       <Grid item gap={3}>
         <Typography variant="subtitle2">
@@ -33,7 +33,7 @@ export default function MetaPromptForm() {
             multiline
             size="small"
             name="Quiz metaPrompt Input"
-            placeholder="Example: ask questions as a mysterious wizard..."
+            placeholder="Example: Create questions suitable for high school students familiar with programming concepts but new to the language. Emphasize syntax and programming language quirks over fundamental concepts."
             fullWidth
             variant="standard"
             value={newQuizData.metaPrompt}

--- a/src/Components/CreateQuiz/FormContainer/index.tsx
+++ b/src/Components/CreateQuiz/FormContainer/index.tsx
@@ -4,7 +4,7 @@ import { useAtom } from "jotai";
 import { activeStepAtom } from "../../../Views/CreateQuiz/atoms";
 import KeywordsForm from "./FormSteps/KeywordsForm";
 import SourceUploadForm from "./FormSteps/SourceUploadForm";
-import MetaPromptForm from "./FormSteps/MetaPromptForm";
+import QuizInstructionsForm from "./FormSteps/QuizInstructionsForm";
 
 export default function CreateQuizFormContainer() {
   const [activeStep] = useAtom(activeStepAtom);
@@ -18,7 +18,7 @@ export default function CreateQuizFormContainer() {
       case 2:
         return <KeywordsForm />;
       case 3:
-        return <MetaPromptForm />;
+        return <QuizInstructionsForm />;
       default:
         throw new Error("Unknown step");
     }
@@ -31,6 +31,12 @@ export default function CreateQuizFormContainer() {
       minHeight={"10rem"}
       gap={"1rem"}
       alignContent={"space-between"}
+      sx={{
+        "& .MuiInputBase-input": {
+          fontSize: "0.9rem",
+          lineHeight: 2,
+        },
+      }}
     >
       <Grid item xs={11}>
         {getStepContent(activeStep)}

--- a/src/Components/QuizDetails/SideMenu/QuizInfoSection.tsx
+++ b/src/Components/QuizDetails/SideMenu/QuizInfoSection.tsx
@@ -12,7 +12,7 @@ export const QuizInfoSection = ({ quiz }: { quiz: QuizType }) => {
       val: quiz.quiz_description,
     },
     { title: "Keywords", val: quiz.keywords },
-    { title: "Metaprompt", val: quiz.meta_prompt },
+    { title: "Quiz Level Instructions", val: quiz.meta_prompt },
   ];
 
   return (

--- a/src/Views/CreateQuiz/atoms.ts
+++ b/src/Views/CreateQuiz/atoms.ts
@@ -4,7 +4,7 @@ export const stepNamesAtom = atom([
   "Quiz Info",
   "Sources",
   "Keywords & Concepts",
-  "Quiz Instructions",
+  "Quiz Level Instructions",
 ]);
 
 export const activeStepAtom = atom(0);

--- a/src/Views/CreateQuiz/atoms.ts
+++ b/src/Views/CreateQuiz/atoms.ts
@@ -4,7 +4,7 @@ export const stepNamesAtom = atom([
   "Quiz Info",
   "Sources",
   "Keywords & Concepts",
-  "Meta-prompts",
+  "Quiz Instructions",
 ]);
 
 export const activeStepAtom = atom(0);


### PR DESCRIPTION
### Description

This PR updates the naming and examples for quiz metaprompts. By renaming it to quiz level instructions and providing a clear example in the input placeholder, user's will have a clearer understanding of the purpose of that field

### Checklist

- [ ] I tested the implementation on Preview link and everything works as expected
- [ ] I fixed all the issues found by the linter
- [ ] I extended README / documentation, if necessary

### Screenshot (optional)
