### PR TITLE
feat: accept only PDF files on file upload

### DIFF
--- a/src/Components/CreateQuiz/FormContainer/FormSteps/SourceUploadForm.tsx
+++ b/src/Components/CreateQuiz/FormContainer/FormSteps/SourceUploadForm.tsx
@@ -42,6 +42,10 @@ export default function SourceUploadForm() {
   return (
     <Grid container>
       <FormStepTitle>Upload Source</FormStepTitle>
+      <Typography variant="subtitle2" mb={3}>
+        Upload a file to generate questions from. Note: The application
+        currently supports only <strong>PDF</strong> format.
+      </Typography>
       <Grid container spacing={3}>
         <Grid item xs={12} sm={12}>
           <Button
@@ -52,7 +56,11 @@ export default function SourceUploadForm() {
             fullWidth
           >
             Upload file
-            <VisuallyHiddenInput type="file" onChange={handleChange} />
+            <VisuallyHiddenInput
+              type="file"
+              onChange={handleChange}
+              accept="application/pdf"
+            />
           </Button>
         </Grid>
         <SelectedFilesBox


### PR DESCRIPTION
### Description

This PR adds an accept field to file upload input to accept only PDF files. It also adds a subtitle to the component to communicate that with the user.

### Checklist

- [ ] I tested the implementation on Preview link and everything works as expected
- [ ] I fixed all the issues found by the linter
- [ ] I extended README / documentation, if necessary

### Screenshot (optional)
