### PR TITLE
feat: add checks for file size

### DIFF
--- a/src/Api/quizzes.ts
+++ b/src/Api/quizzes.ts
@@ -29,10 +29,19 @@ interface CreateQuizRequestType {
 const CreateQuizFn = async (props: CreateQuizRequestType) => {
   const formData = new FormData();
 
+  if (!props.quizTitle) {
+    alert("Please provide a name for your quiz.");
+    return;
+  }
+
+  if (props.files[0].size > 19999999) {
+    alert("File size exceeds the limit.");
+    return;
+  }
+
   formData.append("quiz_title", props.quizTitle);
   formData.append("quiz_description", props.description);
   formData.append("keywords", props.keywords.join(","));
-  // To-do: create a loop to append multiple files
   formData.append("source_file", props.files[0]);
   formData.append("meta_prompt", props.metaPrompt);
 

--- a/src/Components/CreateQuiz/FormContainer/FormSteps/SourceUploadForm.tsx
+++ b/src/Components/CreateQuiz/FormContainer/FormSteps/SourceUploadForm.tsx
@@ -25,6 +25,11 @@ export default function SourceUploadForm() {
   const [newQuizData, setNewQuizData] = useAtom(newQuizDataAtom);
 
   const handleChange = (e: any) => {
+    if (e.target.files[0].size > 19999000) {
+      alert("File exceeds the size limit.");
+      e.target.value = null;
+      return;
+    }
     setNewQuizData({
       ...newQuizData,
       files: [e.target.files[0]],
@@ -45,6 +50,8 @@ export default function SourceUploadForm() {
       <Typography variant="subtitle2" mb={3}>
         Upload a file to generate questions from. Note: The application
         currently supports only <strong>PDF</strong> format.
+        <br />
+        (Max file size: 20MB)
       </Typography>
       <Grid container spacing={3}>
         <Grid item xs={12} sm={12}>


### PR DESCRIPTION
### Description

This PR adds a validation for file size, which is currently set to 20 MB. Inputs are validated. Additional validation is added to the create quiz function.

### Checklist

- [ ] I tested the implementation on Preview link and everything works as expected
- [ ] I fixed all the issues found by the linter
- [ ] I extended README / documentation, if necessary

### Screenshot (optional)
